### PR TITLE
화면 분기 로직 routes => layout 폴더로 이동

### DIFF
--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -1,10 +1,10 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import useLoggedInUserStore from '../libs/store/store';
+import useLoggedInUserStore from '../../libs/store/store';
 
-const PrivateRoutes = () => {
+const AuthLayout = () => {
   const { loggedInUser } = useLoggedInUserStore();
   if (loggedInUser) return <Navigate to="/" />;
   return <Outlet />;
 };
 
-export default PrivateRoutes;
+export default AuthLayout;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import MenuDropDown from '../dropdown/MenuDropDown';
 import ConfigDropDown from '../dropdown/ConfigDropdown';
@@ -153,29 +152,23 @@ export default function Header() {
                 <ConfigDropDown isOpen={isOpenConfigDropdown} />
               </Config>
             </AlarmAndSetting>
-            {loggedInUser ? (
-              <ProfileWrap>
-                <img src={profileDefault} alt="프로필 이미지" />
-                <Profile>
-                  <UserInfo>
-                    <UserInfoHeader>{loggedInUser || 'Name'}</UserInfoHeader>
-                    <UserInfoFooter>UI Designer</UserInfoFooter>
-                  </UserInfo>
-                </Profile>
-                <More ref={profileDropdownRef}>
-                  <img
-                    src={more}
-                    alt="프로필 더 보기"
-                    onClick={toggleProfileDropdown}
-                  />
-                  <MenuDropDown isOpen={isOpenProfileDropdown} />
-                </More>
-              </ProfileWrap>
-            ) : (
-              <>
-                <Link to="/login">로그인</Link>
-              </>
-            )}
+            <ProfileWrap>
+              <img src={profileDefault} alt="프로필 이미지" />
+              <Profile>
+                <UserInfo>
+                  <UserInfoHeader>{loggedInUser || 'Name'}</UserInfoHeader>
+                  <UserInfoFooter>UI Designer</UserInfoFooter>
+                </UserInfo>
+              </Profile>
+              <More ref={profileDropdownRef}>
+                <img
+                  src={more}
+                  alt="프로필 더 보기"
+                  onClick={toggleProfileDropdown}
+                />
+                <MenuDropDown isOpen={isOpenProfileDropdown} />
+              </More>
+            </ProfileWrap>
           </ToolContainer>
         </HeaderList>
       </Navigation>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Outlet } from 'react-router-dom';
+
 import Header from './Header';
 import SideBar from './SideBar';
 
@@ -12,13 +14,15 @@ const Main = styled.main`
   padding-bottom: 30px;
 `;
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout() {
   return (
     <>
       <Header />
       <>
         <SideBar />
-        <Main>{children}</Main>
+        <Main>
+          <Outlet />
+        </Main>
       </>
     </>
   );

--- a/src/components/layout/PublicLayout.tsx
+++ b/src/components/layout/PublicLayout.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import axios, { AxiosResponse } from 'axios';
-import useLoggedInUserStore from '../libs/store/store';
 
-const PublicRoutes = () => {
+import useLoggedInUserStore from '../../libs/store/store';
+
+const PublicLayout = () => {
   const [failedAuth, setFailedAuth] = useState(false);
   const { loggedInUser, setLoggedInUser } = useLoggedInUserStore();
 
@@ -25,8 +26,8 @@ const PublicRoutes = () => {
     getLoggedUser().then((username) => setLoggedInUser(username));
   }, []);
 
-  if (loggedInUser || !failedAuth) return <Outlet />;
-  return <Navigate to={'/login'} />;
+  if (!loggedInUser || failedAuth) return <Navigate to="/login" />;
+  return <Outlet />;
 };
 
-export default PublicRoutes;
+export default PublicLayout;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,6 @@ import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
 import { CookiesProvider } from 'react-cookie';
 import reportWebVitals from './reportWebVitals';
-import Layout from './components/layout/Layout';
 import MainRoutes from './routes/MainRoute';
 
 const root = ReactDOM.createRoot(
@@ -31,9 +30,7 @@ root.render(
     <GlobalStyle />
     <CookiesProvider>
       <BrowserRouter>
-        <Layout>
-          <MainRoutes />
-        </Layout>
+        <MainRoutes />
       </BrowserRouter>
     </CookiesProvider>
   </React.StrictMode>,

--- a/src/routes/MainRoute.tsx
+++ b/src/routes/MainRoute.tsx
@@ -9,30 +9,34 @@ import SignUp from '../pages/SignUp';
 import Home from '../pages/Home';
 import ProfileRoute from './ProfileRoute';
 import SettingsRoute from './SettingsRoute';
-import PrivateRoutes from './PrivateRoutes';
-import PublicRoutes from './PublicRoutes';
 import ModifyUser from '../pages/user/Modify';
 import FindId from '../pages/user/FindId';
 import FindPassword from '../pages/user/FindPassword';
+import Layout from '../components/layout/Layout';
+import AuthLayout from '../components/layout/AuthLayout';
+import PublicLayout from '../components/layout/PublicLayout';
 
 const MainRoutes = () => (
   <Routes>
     {/* routes not auth only */}
-    <Route element={<PrivateRoutes />}>
+    <Route element={<Layout />}>
+      <Route element={<PublicLayout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/profile/*" element={<ProfileRoute />} />
+        <Route path="/settings/*" element={<SettingsRoute />} />
+        {/* 아래 user쪽 route는 추후 정리 필요해 보임 */}
+        <Route path="/:userId/modify" element={<ModifyUser />}></Route>
+        <Route path="/user/find/userId" element={<FindId />}></Route>
+        <Route path="/user/find/password" element={<FindPassword />}></Route>
+      </Route>
+    </Route>
+
+    <Route element={<AuthLayout />}>
       <Route path="/login" element={<Login />}></Route>
       <Route path="/signup" element={<SignUp />}></Route>
     </Route>
 
     {/* routes auth only */}
-    <Route element={<PublicRoutes />}>
-      <Route path="/" element={<Home />} />
-      <Route path="/profile/*" element={<ProfileRoute />} />
-      <Route path="/settings/*" element={<SettingsRoute />} />
-      {/* 아래 user쪽 route는 추후 정리 필요해 보임 */}
-      <Route path="/:userId/modify" element={<ModifyUser />}></Route>
-      <Route path="/user/find/userId" element={<FindId />}></Route>
-      <Route path="/user/find/password" element={<FindPassword />}></Route>
-    </Route>
 
     <Route path={'*'} element={<NotFound />}></Route>
   </Routes>


### PR DESCRIPTION
- routes 폴더에서는 라우트 기능만 유지하도록 하기 위해 기존의 인증 확인 및 권한 동작을 layout 폴더의 컴포넌트에서 수행하도록 변경했습니다.
- 추가로 root/index.tsx의 Layout 컴포넌트를 로그인/회원가입 페이지에서는 보이지 않도록 MainRoutes에서 렌더링되도록 변경했습니다. 